### PR TITLE
Centos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.0 )
+cmake_minimum_required( VERSION 3.1 )
 
 include(CMakeScripts/ConfigEnv.cmake)
 include(FindPkgConfig)
@@ -37,11 +37,8 @@ endif()
 option( VERBOSE "Show information about CMake build configuration." )
 
 # Enable C++11 builds
-# TODO: With CMake > 3.1, can use target_compile_features() to do this automatically
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-#ADD_DEFINITIONS(-DARMA_DONT_USE_CXX11)
 
 # Define minimum versions of dependencies here
 set(ARMADILLO_REQUIRED_VERSION 4.000)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,10 @@ option( VERBOSE "Show information about CMake build configuration." )
 
 # Enable C++11 builds
 # TODO: With CMake > 3.1, can use target_compile_features() to do this automatically
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+#ADD_DEFINITIONS(-DARMA_DONT_USE_CXX11)
 
 # Define minimum versions of dependencies here
 set(ARMADILLO_REQUIRED_VERSION 4.000)

--- a/scripts/build_centos.sh
+++ b/scripts/build_centos.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+#based on
+#https://sourceforge.net/p/qwwad/wiki/Installing%20from%20a%20package/
+
+# This script builds qwwad on the centos 6 platform
+# to be more widely compatible across Linux distributions
+
+# To be run from project root
+
+yum install -y epel-release
+yum update -y
+yum install -y gcc gcc-c++ gcc-gfortran help2man armadillo-devel boost148-program-options boost148-devel gsl-devel lapack-devel libxml++-devel cmake3 git wget
+
+if [ ! -f /etc/yum.repos.d/devtools-2.repo ]; then \
+  wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo
+fi
+yum install -y devtoolset-2-gcc devtoolset-2-binutils devtoolset-2-gcc-c++ devtoolset-2-gcc-gfortran
+
+#scl enable devtoolset-2 bash
+export CMAKE_CXX_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/g++
+export CMAKE_FORTRAN_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/gfortran
+export CMAKE_C_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/gcc
+export CMAKE_INSTALL_PREFIX=${HOME}/qwwad
+
+
+
+#cd ${HOME}
+#git clone https://github.com/QWWAD/qwwad.git
+#cd qwwad
+ln -sf /usr/include/boost148/boost /usr/include/boost
+ln -sf /usr/lib64/libboost_program_options-mt.so.1.48.0 /usr/lib64/libboost_program_options-mt.so
+ln -sf /usr/lib64/libboost_program_options.so.1.48.0 /usr/lib64/libboost_program_options.so
+
+(rm -rf build && mkdir build && cd build && cmake3 -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} ..)
+(cd build && make -j2)
+(cd build && make install)
+

--- a/scripts/build_centos.sh
+++ b/scripts/build_centos.sh
@@ -5,9 +5,9 @@ set -e
 #https://sourceforge.net/p/qwwad/wiki/Installing%20from%20a%20package/
 
 # This script builds qwwad on the centos 6 platform
-# to be more widely compatible across Linux distributions
-
-# To be run from project root
+# This successfully builds in a docker image with all of the
+# following dependencies installed
+# To be run from the project root
 
 yum install -y epel-release
 yum update -y

--- a/scripts/build_centos.sh
+++ b/scripts/build_centos.sh
@@ -33,7 +33,9 @@ ln -sf /usr/include/boost148/boost /usr/include/boost
 ln -sf /usr/lib64/libboost_program_options-mt.so.1.48.0 /usr/lib64/libboost_program_options-mt.so
 ln -sf /usr/lib64/libboost_program_options.so.1.48.0 /usr/lib64/libboost_program_options.so
 
-(rm -rf build && mkdir build && cd build && cmake3 -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} ..)
+(rm -rf build && mkdir build && cd build && cmake3 -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} \
+        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} \
+        ..)
 (cd build && make -j2)
 (cd build && make install)
 


### PR DESCRIPTION
scripts/build_centos.sh
this file can build qwwad from a bare docker image on a Redhat 6 compatible os, Centos

CMakeLists.txt
changed so that C++ 11 standard can be enforced, no matter what compiler is being used.
